### PR TITLE
Installation only works with Lua 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,13 @@
 
 You are welcome to use this code for research purposes but it is not actively supported. 
 
-Here are some pointers on getting it to work:
+### Instalation
 
-You will need to compile the rock first. In the file spectralnet-scm-1.rockspec, change the line
-url = "..." --TODO
-to url = "."
-or url = "/path/to/spectral-lib"
+Your torch version must be installed with `TORCH_LUA_VERSION=LUA51`. (See mbhenaff/spectral-lib#11)
 
-Then run:
+Clone the repo, cd to it and then run:
 
-luarocks install spectralnet-scm-1.rockspec
+`luarocks install spectralnet-scm-1.rockspec`
 
 To run on MNIST/CIFAR, download the datasets and change the paths in test/datasource.lua
 

--- a/spectralnet-scm-1.rockspec
+++ b/spectralnet-scm-1.rockspec
@@ -1,7 +1,7 @@
 package = "spectralnet"
 version = "scm-1"
 source = {
-   url = "..." --TODO
+   url = "." --TODO
 }
 description = {
    summary = "Spectral network library",


### PR DESCRIPTION
I have updated the README to point out that installation only works when torch is installed with  Lua 5.1  (see mbhenaff/spectral-lib#11)
I have also updated the url of `spectralnet-scm-1.rockspec` to be the current folder as default. So it works without editing the file. 
